### PR TITLE
Fix complete removal of deleted extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/app/graphdb/bsl_code_sqlite.py
+++ b/app/graphdb/bsl_code_sqlite.py
@@ -900,6 +900,24 @@ class BslCodeSqlite:
             ),
         )
 
+    def count_units_for_config(self, scope: str, config_name: str) -> int:
+        """Count committed code-search units owned by one configuration.
+
+        Used as a removal postcondition before incremental extension state is
+        discarded. Reading only the current epoch avoids false positives from
+        retired epochs that are waiting for normal GC.
+        """
+        epoch = self.get_current_epoch(scope)
+        if epoch is None:
+            return 0
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT COUNT(*) AS cnt FROM bsl_code_units "
+                "WHERE project_name = ? AND index_epoch = ? AND config_name = ?",
+                (scope, int(epoch), config_name),
+            ).fetchone()
+        return int(row["cnt"] if row else 0)
+
     def fts_bm25(
         self,
         scope: str,

--- a/app/graphdb/incremental_loader.py
+++ b/app/graphdb/incremental_loader.py
@@ -523,6 +523,86 @@ class IncrementalLoaderMixin:
                     break
         return total
 
+    def delete_extension_scope(
+        self,
+        project_name: str,
+        config_name: str,
+        batch_size: Optional[int] = None,
+    ) -> int:
+        """Delete every node owned by one extension configuration.
+
+        Extension form internals do not consistently carry ``project_name``.
+        Ownership is therefore proven by the exact ``config_name`` together
+        with at least one project-qualified property (project, QN or owner QN).
+        The Configuration node itself has no ``config_name`` and is matched by
+        its exact qualified name.
+        """
+        if not project_name or not config_name:
+            raise ValueError("project_name and config_name are required")
+        bs = batch_size or settings.neo4j_batch_size
+        config_qn = f"{project_name}/{config_name}"
+        config_prefix = config_qn + "/"
+        total = 0
+        cypher = """
+        MATCH (n)
+        WHERE (n.project_name = $project_name AND n.config_name = $config_name)
+           OR n.qualified_name = $config_qn
+           OR (n.qualified_name IS NOT NULL
+               AND n.qualified_name STARTS WITH $config_prefix)
+           OR n.owner_qn = $config_qn
+           OR (n.owner_qn IS NOT NULL
+               AND n.owner_qn STARTS WITH $config_prefix)
+        WITH n LIMIT $batch_size
+        DETACH DELETE n
+        RETURN count(n) AS deleted
+        """
+        with self.driver.session(database=settings.neo4j_database) as session:
+            while True:
+                rec = session.run(
+                    cypher,
+                    project_name=project_name,
+                    config_name=config_name,
+                    config_qn=config_qn,
+                    config_prefix=config_prefix,
+                    batch_size=bs,
+                ).single()
+                deleted = int(rec["deleted"] if rec else 0)
+                total += deleted
+                if deleted < bs:
+                    break
+        return total
+
+    def count_extension_scope_nodes(
+        self,
+        project_name: str,
+        config_name: str,
+    ) -> int:
+        """Return nodes matching the same ownership predicate as purge."""
+        if not project_name or not config_name:
+            return 0
+        config_qn = f"{project_name}/{config_name}"
+        config_prefix = config_qn + "/"
+        with self.driver.session(database=settings.neo4j_database) as session:
+            rec = session.run(
+                """
+                MATCH (n)
+                WHERE (n.project_name = $project_name
+                       AND n.config_name = $config_name)
+                   OR n.qualified_name = $config_qn
+                   OR (n.qualified_name IS NOT NULL
+                       AND n.qualified_name STARTS WITH $config_prefix)
+                   OR n.owner_qn = $config_qn
+                   OR (n.owner_qn IS NOT NULL
+                       AND n.owner_qn STARTS WITH $config_prefix)
+                RETURN count(n) AS count
+                """,
+                project_name=project_name,
+                config_name=config_name,
+                config_qn=config_qn,
+                config_prefix=config_prefix,
+            ).single()
+        return int(rec["count"] if rec else 0)
+
     # ------------------------------------------------------------------
     # delete_metadata_object_node + empty category cleanup
     # ------------------------------------------------------------------

--- a/app/incremental/artifact_sync.py
+++ b/app/incremental/artifact_sync.py
@@ -153,6 +153,10 @@ class CodeArtifactCycleContext:
     # Используется post-link consumers и base form impact lookup.
     known_extension_configs: Dict[str, str] = field(default_factory=dict)  # ext_dir -> ext_config_name
 
+    # Phase-1 scopes whose top-level extension directory disappeared.
+    # Kept in state until BSL sidecar cleanup and graph postconditions succeed.
+    removed_extension_scopes: Dict[str, str] = field(default_factory=dict)
+
     # SSL: при изменении подсистем СтандартныеПодсистемы (Состав / ПутьПодсистемы)
     # incremental пайплайн поднимает этот флаг — scheduler после BSL apply
     # запускает loader.refresh_ssl_api_for_project. Scoped refresh для затронутых
@@ -180,6 +184,8 @@ class CodeArtifactCycleContext:
     # `BslCodeSearchSync` сам триггерит full rebuild через reindex_requested.
     bsl_code_search_delta_applier: Any = None
     bsl_code_search_scope: Optional[str] = None
+    bsl_code_search_indexer: Any = None
+    bsl_code_search_sqlite: Any = None
 
     def graph_changed(self) -> bool:
         """True если artifact/BSL-фаза действительно изменила Neo4j-граф в этом цикле.
@@ -946,6 +952,22 @@ class ArtifactSync:
             if extensions_dir is None:
                 continue
             ext_code_dir = extensions_dir / ext_dir_name / "code"
+            if scope in context.removed_extension_scopes:
+                ext_summaries = self._prepare_removed_extension_bsl(
+                    settings_obj=settings_obj,
+                    context=context,
+                    lease=lease,
+                    source_mode=source_mode,
+                    source_scope=scope,
+                    ext_dir_name=ext_dir_name,
+                    ext_config_name=ext_config_name,
+                    ext_code_dir=ext_code_dir,
+                )
+                all_summaries[ext_dir_name] = ext_summaries
+                _log_extension_summary(ext_dir_name, ext_summaries)
+                if lease is not None:
+                    lease.heartbeat()
+                continue
             if not ext_code_dir.exists():
                 continue
 
@@ -1211,6 +1233,135 @@ class ArtifactSync:
                 lease.heartbeat()
 
         return all_summaries
+
+    def _prepare_removed_extension_bsl(
+        self,
+        *,
+        settings_obj: Any,
+        context: CodeArtifactCycleContext,
+        lease: Optional[LockLease],
+        source_mode: str,
+        source_scope: str,
+        ext_dir_name: str,
+        ext_config_name: str,
+        ext_code_dir: Path,
+    ) -> Dict[str, ArtifactSummary]:
+        """Feed every saved BSL file of a removed extension into normal delta cleanup.
+
+        The directory no longer exists, so a regular code-index scan cannot
+        produce ``deleted`` paths. The artifact manifest is the authoritative
+        baseline and remains available because phase 1 only registered the
+        pending removal.
+        """
+        scope_bsl = ext_artifact_scope(source_mode, ext_dir_name, "bsl")
+        # Use both baselines. A partially failed earlier cycle can remove an
+        # artifact_manifest row while retaining bsl_file_artifacts (or vice
+        # versa); the union preserves every routine/module ID available for
+        # cleanup.
+        deleted_path_set = set(
+            self.state.all_artifact_manifest_rel_paths(scope_bsl)
+        )
+        deleted_path_set.update(
+            row["rel_path"]
+            for row in self.state.all_bsl_file_artifacts(scope_bsl)
+            if row.get("rel_path")
+        )
+        deleted_paths = sorted(deleted_path_set)
+        diff = ArtifactDiff(deleted=deleted_paths)
+        context.affected_artifacts[scope_bsl] = diff
+        if deleted_paths:
+            self._apply_bsl(
+                project_name=context.project_name,
+                config_name=ext_config_name,
+                source_scope=scope_bsl,
+                root=ext_code_dir,
+                diff=diff,
+                extra_files_to_parse=[],
+                extras_manifest_scope=ext_artifact_scope(
+                    source_mode, ext_dir_name, "form_bin"
+                ),
+                context=context,
+                settings_obj=settings_obj,
+                lease=lease,
+            )
+        else:
+            logger.warning(
+                "Removed extension has no BSL artifact baseline: scope=%s",
+                source_scope,
+            )
+        return {
+            scope_bsl: ArtifactSummary(deleted=len(deleted_paths)),
+        }
+
+    def finalize_removed_extensions(
+        self,
+        *,
+        settings_obj: Any,
+        context: CodeArtifactCycleContext,
+        report: Any,
+        lease: Optional[LockLease] = None,
+    ) -> int:
+        """Purge graph residue and discard state only after BSL cleanup succeeded."""
+        total_deleted = 0
+        code_search_enabled = bool(
+            getattr(settings_obj, "enable_bsl_code_search", False)
+        )
+        sqlite = context.bsl_code_search_sqlite
+        sqlite_scope = context.bsl_code_search_scope or context.project_name
+
+        for source_scope, config_name in sorted(
+            context.removed_extension_scopes.items()
+        ):
+            if code_search_enabled:
+                if sqlite is None:
+                    raise RuntimeError(
+                        f"BSL code-search sidecar unavailable for {source_scope}"
+                    )
+                remaining_units = sqlite.count_units_for_config(
+                    sqlite_scope, config_name
+                )
+                if remaining_units:
+                    raise RuntimeError(
+                        f"BSL cleanup incomplete for {source_scope}: "
+                        f"{remaining_units} units remain"
+                    )
+
+            deleted = self.loader.delete_extension_scope(
+                context.project_name, config_name
+            )
+            total_deleted += deleted
+            if lease is not None:
+                lease.heartbeat()
+
+            remaining_nodes = self.loader.count_extension_scope_nodes(
+                context.project_name, config_name
+            )
+            if remaining_nodes:
+                raise RuntimeError(
+                    f"graph cleanup incomplete for {source_scope}: "
+                    f"{remaining_nodes} nodes remain"
+                )
+
+            # Destructive state transition is deliberately last. If any
+            # postcondition above fails, manifests remain available for retry.
+            with self.state.transaction():
+                self.state.delete_scope(source_scope)
+            context.known_extension_configs.pop(
+                source_scope.split(":", 1)[-1], None
+            )
+            report.notes.append(
+                f"extension scope removed: scope={source_scope} "
+                f"config={config_name} graph_nodes={deleted}"
+            )
+            logger.info(
+                "Extension scope removed completely: scope=%s "
+                "ext_graph_config_name=%s graph_nodes=%d",
+                source_scope,
+                config_name,
+                deleted,
+            )
+
+        return total_deleted
 
     # -- Apply helpers -----------------------------------------------
 

--- a/app/incremental/metadata_sync.py
+++ b/app/incremental/metadata_sync.py
@@ -1451,7 +1451,7 @@ class MetadataIncrementalSync:
         Шаги (см. план §5):
         1. extensions_directory не существует → выход.
         2. Top-level diff: scope-ы в state vs фактические каталоги на диске →
-           удалённые получают `_apply_ext_removed` с graph cfg name из state.
+           удалённые регистрируются для deferred purge после artifact/BSL-фаз.
         3. Для каждого фактического `<ext_dir>`:
            - validation структуры (`metadata/` + единственный `.txt`);
            - при failed validation И существующем scope — `_apply_ext_removed`;
@@ -1478,13 +1478,16 @@ class MetadataIncrementalSync:
             ext_graph_config_name = self._extract_ext_cfg_name_from_state(
                 scope, project_name
             )
-            _apply_ext_removed(
-                loader=self.loader,
-                state=self.state,
-                source_scope=scope,
-                project_name=project_name,
-                ext_graph_config_name=ext_graph_config_name,
-            )
+            if ext_graph_config_name:
+                report.removed_extension_scopes[scope] = ext_graph_config_name
+                report.notes.append(
+                    f"extension removal deferred: scope={scope} "
+                    f"config={ext_graph_config_name}"
+                )
+            else:
+                report.errors.append(
+                    f"cannot defer extension removal without config name: scope={scope}"
+                )
 
         # 3. Per-extension.
         for ext_dir in sorted(ext_dirs, key=lambda d: d.name):
@@ -1498,28 +1501,34 @@ class MetadataIncrementalSync:
             # Validation as full load does.
             if not ext_metadata_dir.exists():
                 if scope_exists:
-                    _apply_ext_removed(
-                        loader=self.loader,
-                        state=self.state,
-                        source_scope=source_scope,
-                        project_name=project_name,
-                        ext_graph_config_name=self._extract_ext_cfg_name_from_state(
-                            source_scope, project_name
-                        ),
+                    ext_graph_config_name = self._extract_ext_cfg_name_from_state(
+                        source_scope, project_name
                     )
+                    if ext_graph_config_name:
+                        report.removed_extension_scopes[source_scope] = (
+                            ext_graph_config_name
+                        )
+                    else:
+                        report.errors.append(
+                            f"cannot defer invalid extension removal without "
+                            f"config name: scope={source_scope}"
+                        )
                 continue
             txt_files = list(ext_metadata_dir.glob("*.txt"))
             if not txt_files or len(txt_files) > 1:
                 if scope_exists:
-                    _apply_ext_removed(
-                        loader=self.loader,
-                        state=self.state,
-                        source_scope=source_scope,
-                        project_name=project_name,
-                        ext_graph_config_name=self._extract_ext_cfg_name_from_state(
-                            source_scope, project_name
-                        ),
+                    ext_graph_config_name = self._extract_ext_cfg_name_from_state(
+                        source_scope, project_name
                     )
+                    if ext_graph_config_name:
+                        report.removed_extension_scopes[source_scope] = (
+                            ext_graph_config_name
+                        )
+                    else:
+                        report.errors.append(
+                            f"cannot defer invalid extension removal without "
+                            f"config name: scope={source_scope}"
+                        )
                 continue
             txt_path = txt_files[0]
             rel_path = txt_path.name

--- a/app/incremental/report.py
+++ b/app/incremental/report.py
@@ -215,6 +215,15 @@ class IncrementalReport:
     # Per-extension sub-reports: key = ext_dir_name, value = IncrementalReport scope-а.
     extension_reports: Dict[str, "IncrementalReport"] = field(default_factory=dict)
 
+    # Top-level extension directories that disappeared in this cycle.
+    # Mapping: phase-1 scope (`xml_ext:<dir>` / `txt_ext:<dir>`) →
+    # graph configuration name (`<Config>$ext$`).
+    #
+    # Removal is intentionally deferred until after artifact/BSL phases: those
+    # phases need the still-intact manifests and bsl_file_artifacts to remove
+    # routines from Neo4j and the code-search sidecar consistently.
+    removed_extension_scopes: Dict[str, str] = field(default_factory=dict)
+
     duration_seconds: float = 0.0
     errors: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)
@@ -234,7 +243,12 @@ class IncrementalReport:
 
     @property
     def has_changes(self) -> bool:
-        if self.added_qns or self.changed_qns or self.deleted_qns:
+        if (
+            self.added_qns
+            or self.changed_qns
+            or self.deleted_qns
+            or self.removed_extension_scopes
+        ):
             return True
         return any(sub.has_changes for sub in self.extension_reports.values())
 
@@ -272,6 +286,7 @@ class IncrementalReport:
                 self.extension_reports[ext_name] = sub
             else:
                 existing.merge(sub)
+        self.removed_extension_scopes.update(other.removed_extension_scopes)
         self.duration_seconds += other.duration_seconds
         self.errors.extend(other.errors)
         self.notes.extend(other.notes)
@@ -294,6 +309,8 @@ class IncrementalReport:
             parts.append(
                 f"extensions scanned={len(self.extension_reports)} changed={ext_changed}"
             )
+        if self.removed_extension_scopes:
+            parts.append(f"extensions removed={len(self.removed_extension_scopes)}")
         parts.append(
             f"errors={len(self.errors)} duration={self.duration_seconds:.2f}s"
         )

--- a/app/incremental/scheduler.py
+++ b/app/incremental/scheduler.py
@@ -481,6 +481,7 @@ class IncrementalLoadingScheduler(threading.Thread):
             base_configuration=base_configuration,
             ext_configurations=ext_configurations,
             source_mode=getattr(self.settings_obj, "metadata_source", "txt"),
+            removed_extension_scopes=dict(report.removed_extension_scopes),
         )
 
         # Propagate ssl_owners_dirty из report (изменения подсистем в metadata sync)
@@ -629,8 +630,28 @@ class IncrementalLoadingScheduler(threading.Thread):
         except Exception:
             logger.exception("Phase 5 (BSL code search sync) failed")
 
+        removed_extensions_changed = False
+        if context.removed_extension_scopes:
+            try:
+                removed_extensions_changed = bool(
+                    artifact_sync.finalize_removed_extensions(
+                        settings_obj=self.settings_obj,
+                        context=context,
+                        report=report,
+                        lease=lease,
+                    )
+                )
+            except Exception as exc:
+                logger.exception("Extension removal finalization failed")
+                report.errors.append(
+                    f"extension removal finalization failed: {exc!r}"
+                )
+
         artifact_graph_changed = (
-            context.graph_changed() or bool(bsl_changed) or bool(post_linking_changed)
+            context.graph_changed()
+            or bool(bsl_changed)
+            or bool(post_linking_changed)
+            or removed_extensions_changed
         )
         return (
             set(context.metadata_embedding_repass_qns),

--- a/app/incremental/xml_walker.py
+++ b/app/incremental/xml_walker.py
@@ -1002,7 +1002,8 @@ def xml_incremental_run_extensions(
 
     Шаги (см. план §6):
     1. LOAD_EXTENSIONS=false или нет extensions_directory → выход.
-    2. Top-level diff: удалённые scope → `_apply_ext_removed`.
+    2. Top-level diff: удалённые scope регистрируются для deferred purge после
+       artifact/BSL-фаз.
     3. Для каждого живого `<ext_dir>`:
        - validation `code/Configuration.xml`;
        - listing `metadata_xml_files`, candidate detection через mtime+size+hash;
@@ -1034,13 +1035,18 @@ def xml_incremental_run_extensions(
         ext_graph_config_name = _extract_ext_cfg_name_from_state(
             state, scope, project_name
         )
-        _apply_ext_removed(
-            loader=loader,
-            state=state,
-            source_scope=scope,
-            project_name=project_name,
-            ext_graph_config_name=ext_graph_config_name,
-        )
+        if ext_graph_config_name:
+            report.removed_extension_scopes[scope] = ext_graph_config_name
+            report.notes.append(
+                f"extension removal deferred: scope={scope} "
+                f"config={ext_graph_config_name}"
+            )
+        else:
+            # Do not drop state: without the graph config name a scoped purge
+            # cannot be proven safe, and retaining the scope enables retry.
+            report.errors.append(
+                f"cannot defer extension removal without config name: scope={scope}"
+            )
 
     # 3. Per-extension.
     for ext_dir in sorted(ext_dirs, key=lambda d: d.name):
@@ -1053,15 +1059,22 @@ def xml_incremental_run_extensions(
         # Validation: required code/Configuration.xml.
         if not config_xml.exists():
             if scope_exists:
-                _apply_ext_removed(
-                    loader=loader,
-                    state=state,
-                    source_scope=source_scope,
-                    project_name=project_name,
-                    ext_graph_config_name=_extract_ext_cfg_name_from_state(
-                        state, source_scope, project_name
-                    ),
+                ext_graph_config_name = _extract_ext_cfg_name_from_state(
+                    state, source_scope, project_name
                 )
+                if ext_graph_config_name:
+                    report.removed_extension_scopes[source_scope] = (
+                        ext_graph_config_name
+                    )
+                    report.notes.append(
+                        f"extension removal deferred after validation failure: "
+                        f"scope={source_scope} config={ext_graph_config_name}"
+                    )
+                else:
+                    report.errors.append(
+                        f"cannot defer invalid extension removal without config "
+                        f"name: scope={source_scope}"
+                    )
             continue
 
         sub_report = IncrementalReport(source_type=source_scope)

--- a/tests/test_removed_extension_cleanup.py
+++ b/tests/test_removed_extension_cleanup.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "app"
+if str(APP) not in sys.path:
+    sys.path.insert(0, str(APP))
+
+from incremental.artifact_sync import (  # noqa: E402
+    ArtifactDiff,
+    ArtifactSync,
+    CodeArtifactCycleContext,
+)
+from incremental.report import IncrementalReport  # noqa: E402
+from incremental import xml_walker  # noqa: E402
+
+
+PROJECT = "БУХ_ПРОД"
+EXT_DIR = "InfostartToolkitCORP"
+SOURCE_SCOPE = f"xml_ext:{EXT_DIR}"
+CONFIG_NAME = f"{EXT_DIR}$ext$"
+CONFIG_QN = f"{PROJECT}/{CONFIG_NAME}"
+
+
+class FakeState:
+    def __init__(
+        self,
+        *,
+        bsl_paths: set[str] | None = None,
+        bsl_sidecar_paths: set[str] | None = None,
+    ) -> None:
+        self.bsl_paths = bsl_paths or set()
+        self.bsl_sidecar_paths = bsl_sidecar_paths or set()
+        self.deleted_scopes: list[str] = []
+
+    def all_artifact_manifest_rel_paths(self, source_scope: str) -> set[str]:
+        return set(self.bsl_paths)
+
+    def all_bsl_file_artifacts(self, source_scope: str) -> list[dict[str, str]]:
+        return [{"rel_path": path} for path in self.bsl_sidecar_paths]
+
+    def delete_scope(self, source_scope: str) -> None:
+        self.deleted_scopes.append(source_scope)
+
+    def transaction(self):
+        return nullcontext()
+
+
+class FakeSqlite:
+    def __init__(self, remaining: int = 0, events: list[str] | None = None) -> None:
+        self.remaining = remaining
+        self.events = events if events is not None else []
+
+    def count_units_for_config(self, scope: str, config_name: str) -> int:
+        self.events.append("check_bsl")
+        self.last_args = (scope, config_name)
+        return self.remaining
+
+
+class FakeLoader:
+    def __init__(
+        self,
+        *,
+        remaining_graph: int = 0,
+        events: list[str] | None = None,
+    ) -> None:
+        self.remaining_graph = remaining_graph
+        self.events = events if events is not None else []
+
+    def delete_extension_scope(self, project_name: str, config_name: str) -> int:
+        self.events.append("delete_graph")
+        self.delete_args = (project_name, config_name)
+        return 27
+
+    def count_extension_scope_nodes(
+        self, project_name: str, config_name: str
+    ) -> int:
+        self.events.append("check_graph")
+        return self.remaining_graph
+
+
+class RemovedExtensionCleanupTests(unittest.TestCase):
+    def _context(
+        self,
+        *,
+        sqlite: FakeSqlite | None = None,
+    ) -> CodeArtifactCycleContext:
+        return CodeArtifactCycleContext(
+            project_name=PROJECT,
+            base_config_name="БухгалтерияПредприятия",
+            base_code_directory=Path("/missing/base"),
+            source_mode="xml",
+            removed_extension_scopes={SOURCE_SCOPE: CONFIG_NAME},
+            known_extension_configs={EXT_DIR: CONFIG_NAME},
+            bsl_code_search_scope=PROJECT,
+            bsl_code_search_sqlite=sqlite,
+        )
+
+    def test_report_marks_removed_extension_as_change_and_merges_it(self) -> None:
+        root = IncrementalReport(source_type="xml")
+        other = IncrementalReport(source_type="xml")
+        other.removed_extension_scopes[SOURCE_SCOPE] = CONFIG_NAME
+
+        root.merge(other)
+
+        self.assertTrue(root.has_changes)
+        self.assertEqual(
+            {SOURCE_SCOPE: CONFIG_NAME},
+            root.removed_extension_scopes,
+        )
+        self.assertIn("extensions removed=1", root.summary_line())
+
+    def test_xml_top_level_removal_is_deferred_without_deleting_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state = mock.Mock()
+            state.list_extension_scopes.return_value = [SOURCE_SCOPE]
+            state.get_extension_scope_config_qn.return_value = CONFIG_QN
+            settings = SimpleNamespace(
+                load_extensions=True,
+                extensions_directory=Path(tmp),
+                project_name=PROJECT,
+            )
+            report = IncrementalReport(source_type="xml")
+
+            with mock.patch.object(
+                xml_walker,
+                "_detect_base_config_name_xml",
+                return_value="БухгалтерияПредприятия",
+            ):
+                xml_walker.xml_incremental_run_extensions(
+                    loader=mock.Mock(),
+                    state=state,
+                    settings_obj=settings,
+                    report=report,
+                    base_impact=xml_walker.BaseImpact(),
+                )
+
+        self.assertEqual(
+            {SOURCE_SCOPE: CONFIG_NAME},
+            report.removed_extension_scopes,
+        )
+        state.delete_scope.assert_not_called()
+
+    def test_removed_extension_bsl_uses_all_manifest_paths_as_deleted(self) -> None:
+        paths = {
+            f"extensions/{EXT_DIR}/code/CommonModules/A/Ext/Module.bsl",
+            f"extensions/{EXT_DIR}/code/CommonModules/B/Ext/Module.bsl",
+        }
+        sidecar_only_path = (
+            f"extensions/{EXT_DIR}/code/CommonModules/C/Ext/Module.bsl"
+        )
+        state = FakeState(
+            bsl_paths=paths,
+            bsl_sidecar_paths={sidecar_only_path},
+        )
+        sync = ArtifactSync.__new__(ArtifactSync)
+        sync.state = state
+        sync.loader = mock.Mock()
+        captured: dict[str, object] = {}
+
+        def capture_apply_bsl(**kwargs):
+            captured.update(kwargs)
+
+        sync._apply_bsl = capture_apply_bsl
+        context = self._context()
+
+        summaries = sync._prepare_removed_extension_bsl(
+            settings_obj=SimpleNamespace(),
+            context=context,
+            lease=None,
+            source_mode="xml",
+            source_scope=SOURCE_SCOPE,
+            ext_dir_name=EXT_DIR,
+            ext_config_name=CONFIG_NAME,
+            ext_code_dir=Path("/missing/extensions") / EXT_DIR / "code",
+        )
+
+        diff = captured["diff"]
+        self.assertIsInstance(diff, ArtifactDiff)
+        self.assertEqual(sorted(paths | {sidecar_only_path}), diff.deleted)
+        self.assertEqual(CONFIG_NAME, captured["config_name"])
+        self.assertEqual(3, next(iter(summaries.values())).deleted)
+
+    def test_finalize_orders_bsl_graph_and_state_cleanup(self) -> None:
+        events: list[str] = []
+        sqlite = FakeSqlite(events=events)
+        loader = FakeLoader(events=events)
+        state = FakeState()
+
+        original_delete_scope = state.delete_scope
+
+        def delete_scope(scope: str) -> None:
+            events.append("delete_state")
+            original_delete_scope(scope)
+
+        state.delete_scope = delete_scope
+        sync = ArtifactSync(loader, state)
+        context = self._context(sqlite=sqlite)
+        report = IncrementalReport(source_type="xml")
+
+        deleted = sync.finalize_removed_extensions(
+            settings_obj=SimpleNamespace(enable_bsl_code_search=True),
+            context=context,
+            report=report,
+        )
+
+        self.assertEqual(27, deleted)
+        self.assertEqual(
+            ["check_bsl", "delete_graph", "check_graph", "delete_state"],
+            events,
+        )
+        self.assertEqual([SOURCE_SCOPE], state.deleted_scopes)
+        self.assertNotIn(EXT_DIR, context.known_extension_configs)
+
+    def test_finalize_keeps_state_when_bsl_cleanup_is_incomplete(self) -> None:
+        events: list[str] = []
+        sqlite = FakeSqlite(remaining=10, events=events)
+        loader = FakeLoader(events=events)
+        state = FakeState()
+        sync = ArtifactSync(loader, state)
+
+        with self.assertRaisesRegex(RuntimeError, "10 units remain"):
+            sync.finalize_removed_extensions(
+                settings_obj=SimpleNamespace(enable_bsl_code_search=True),
+                context=self._context(sqlite=sqlite),
+                report=IncrementalReport(source_type="xml"),
+            )
+
+        self.assertEqual(["check_bsl"], events)
+        self.assertEqual([], state.deleted_scopes)
+
+    def test_finalize_keeps_state_when_graph_postcondition_fails(self) -> None:
+        events: list[str] = []
+        sqlite = FakeSqlite(events=events)
+        loader = FakeLoader(remaining_graph=3, events=events)
+        state = FakeState()
+        sync = ArtifactSync(loader, state)
+
+        with self.assertRaisesRegex(RuntimeError, "3 nodes remain"):
+            sync.finalize_removed_extensions(
+                settings_obj=SimpleNamespace(enable_bsl_code_search=True),
+                context=self._context(sqlite=sqlite),
+                report=IncrementalReport(source_type="xml"),
+            )
+
+        self.assertEqual(["check_bsl", "delete_graph", "check_graph"], events)
+        self.assertEqual([], state.deleted_scopes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- defer top-level extension removal until artifact and BSL cleanup can consume the retained manifests
- purge the extension from the BSL SQLite index and Neo4j, verify both postconditions, then atomically remove incremental state
- cover XML/TXT removal paths and preserve state for retry when cleanup is incomplete

## Проблема
При исчезновении всего каталога расширения `xml_incremental_run_extensions` сразу вызывает `_apply_ext_removed`. Текущая реализация:

1. удаляет только фиксированный набор Neo4j labels;
2. требует `project_name` у дочерних узлов, хотя у элементов форм и команд его нет;
3. не очищает BSL code-search SQLite/FTS;
4. удаляет incremental state и artifact manifests до artifact/BSL-фазы;
5. считает операцию успешной даже после частичных ошибок.

На примере `InfostartToolkitCORP` после удаления Configuration и MetadataObject остались Routine, Module, RoutineCodeUnit, Command и внутренние узлы форм. Через MCP продолжили отвечать `search_bsl_routines`, `get_bsl_routine_body`, `get_bsl_call_graph`, `search_bsl_code`, а через консоль — точечный `/analysis/node`.

## Цель
После удаления каталога расширения не должны оставаться доступные данные:

- в графе Neo4j;
- в incremental state;
- в BSL code-search SQLite, FTS и векторных узлах;
- в MCP-инструментах и API веб-консоли.

Удаление должно быть повторяемым и не терять state до подтверждённого успеха.

## Проектное решение

### 1. Отложить удаление scope
В metadata-фазе только обнаруживать снятый каталог и регистрировать его в `IncrementalReport.removed_extension_scopes`. Не вызывать `state.delete_scope` до artifact/BSL cleanup.

Для каждого scope сохраняются `source_scope`, имя каталога и имя конфигурации расширения.

### 2. Удалить artifact/BSL данные штатным delta-механизмом
До удаления state передать все paths из сохранённых artifact manifests и `bsl_file_artifacts` как `ArtifactDiff.deleted`.

Для BSL переиспользуются `ArtifactSync._apply_bsl` и `BslCodeSearchDeltaApplier`. Это удаляет:

- Routine и Module;
- RoutineCodeUnit и code embeddings;
- строки BSL SQLite и FTS;
- module fragments, methods и phase state;
- corpus IDF/statistics и source-state hash.

### 3. Удалить остаток графа универсальным scope-запросом
После BSL cleanup удалить узлы batched-запросом по совокупности признаков:

- `config_name`;
- `project_name`;
- префикс `qualified_name`;
- префикс `owner_qn`.

Фиксированный список labels не используется. Это покрывает дочерние узлы без `project_name`, не затрагивая одноимённые конфигурации других проектов.

### 4. Удалять state последним
`state.delete_scope` выполняется только после успешных BSL, artifact и graph операций и проверки postcondition.

При ошибке scope/manifests сохраняются для автоматической повторной попытки.

### 5. Проверять результат
Перед логом `Extension scope removed` проверяются:

- ноль Neo4j-узлов по scope-предикату;
- ноль BSL units для `(project_name, config_name)`.

Только после этого фиксируется успешное удаление.

## Test plan
- [x] `python -m compileall -q app tests`
- [x] `git diff --check`
- [x] run `tests/test_removed_extension_cleanup.py` in the project container (6 tests)
- [x] validate deletion of `РасшОпределениеПользователяWindows` on an isolated stack
- [x] validate deletion of `InfostartToolkitCORP` on an isolated stack
- [x] verify zero leftovers in Neo4j, BSL SQLite and incremental state
- [x] verify MCP/console probes and persistence after restart

## Дополнительные сценарии
- [ ] проверить одинаковые имена расширений в разных проектах
- [ ] проверить, что отсутствующий mount переводит цикл в degraded/error и не удаляет все расширения
- [ ] проверить rename расширения — он должен использовать тот же purge